### PR TITLE
fix: remove isomorphic-fetch typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,22 +31,21 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@knisterpeter/standard-tslint": "^1.0.3",
-    "@types/node": "^7.0.0",
-    "ava": "~0.18.0",
-    "coveralls": "^2.11.15",
+    "@knisterpeter/standard-tslint": "^1.3.0",
+    "@types/node": "^7.0.8",
+    "ava": "^0.18.2",
+    "coveralls": "^2.12.0",
     "cz-conventional-changelog": "^2.0.0",
-    "nock": "^9.0.2",
+    "nock": "^9.0.9",
     "nyc": "^10.1.2",
-    "rimraf": "^2.5.4",
+    "rimraf": "^2.6.1",
     "source-map-support": "~0.4.10",
     "standard-version": "^4.0.0",
-    "tslint": "^4.3.1",
-    "typescript": "^2.1.5"
+    "tslint": "^4.5.1",
+    "typescript": "^2.2.1"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
-    "omni-fetch": "^0.2.2"
+    "isomorphic-fetch": "^2.2.1"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "files": [
     "dist",
     "index.d.ts",
-    "src",
-    "typings/isomorphic-fetch.d.ts"
+    "src"
   ],
   "scripts": {
     "linter": "tslint --project ./tsconfig.json --type-check",
@@ -46,7 +45,6 @@
     "typescript": "^2.1.5"
   },
   "dependencies": {
-    "@types/isomorphic-fetch": "^0.0.31",
     "isomorphic-fetch": "^2.2.1",
     "omni-fetch": "^0.2.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import 'isomorphic-fetch';
-import fetch from 'omni-fetch';
 
 export {Get, Post, Put, Delete, Headers} from './decorators';
 


### PR DESCRIPTION
Remove isomorphic-fetch typings since default typings for fetch given by
ts.lib are good enough