### PR TITLE
feat: remove dependency to isomorphic-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Install as npm package:
 npm install pretend --save
 ```
 
+**Note:** To work on node.js (server-side) the `fetch` must be polyfilled. This could easy be done importing `isomorphic-fetch`.
+
 ### API
 
 ```js

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ava": "^0.23.0",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.0.0",
+    "isomorphic-fetch": "2.2.1",
     "nock": "^9.0.22",
     "nyc": "^11.0.2",
     "rimraf": "^2.6.1",
@@ -44,9 +45,6 @@
     "standard-version": "^4.0.0",
     "tslint": "^5.0.0",
     "typescript": "^2.2.1"
-  },
-  "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
   },
   "config": {
     "commitizen": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import 'isomorphic-fetch';
-
 export {Get, Post, Put, Delete, Headers, Patch} from './decorators';
 
 export type IPretendDecoder = (response: Response) => Promise<any>;

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import 'isomorphic-fetch';
 import * as nock from 'nock';
 
 import { Delete, Get, Headers, Post, Pretend, Put, Patch } from '../src';


### PR DESCRIPTION
To work with react-native isomorphic-fetch dependency need to be removed. This means dependents of pretend need to polyfill fetch on node.js side on its own.

BREAKING CHANGE: Remove dependency to isomorphic-fetch