### PR TITLE
fix: add the ability to pass an array of files to append to formData

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -249,6 +249,24 @@ test('Pretend should call a post method with FormData', async () => {
   expect(response).toEqual(mockResponse);
 });
 
+test('Pretend should call a post method with Array of FormData', async () => {
+  const test = setup();
+  nock('http://host:port/', {
+    reqheaders: {
+      'Content-Type': /^multipart\/form-data/
+    }
+  })
+    .post('/path/withFormData', /Content-Disposition: form-data; name="name"/)
+    .reply(200, mockResponse);
+
+  const response = await test.postWithFormData([
+    Buffer.alloc(10).toString('utf-8'),
+    Buffer.alloc(10).toString('utf-8')
+  ]);
+
+  expect(response).toEqual(mockResponse);
+});
+
 test('Pretend should call a post method with FormData and query', async () => {
   const test = setup();
   nock('http://host:port/', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,13 @@ function execute(
           .forEach((parameter: FormDataParameter) => {
             const value = args[parameter.parameter];
             if (value) {
-              formData.append(parameter.name, value, value.name);
+              if (Array.isArray(value)) {
+                value.forEach(val => {
+                  formData.append(parameter.name, val, val.name);
+                });
+              } else {
+                formData.append(parameter.name, value, value.name);
+              }
             }
           });
         return formData;


### PR DESCRIPTION
We have a use case where we want to pass multiple files simultaneously to an API. We should pass the files as an array, which is impossible because the code expects a single file. 